### PR TITLE
init virtio net

### DIFF
--- a/src/hardware/virtio/virtio_net.c
+++ b/src/hardware/virtio/virtio_net.c
@@ -1,0 +1,61 @@
+#include "virtio_net.h"
+#include "virtio_net.h"
+#include "kprintf.h"
+
+static volatile uint8_t *g_net_mmio = NULL;
+
+static volatile uint8_t *probe_net_base(void) {
+    const uintptr_t START  = (uintptr_t)VIRTIO_MMIO_BASE;
+    const uintptr_t STRIDE = 0x1000u;
+    const uintptr_t SLOTS  = 128u;
+    for (uintptr_t i = 0; i < SLOTS; ++i) {
+        volatile uint8_t *b = (volatile uint8_t *)(START + i * STRIDE);
+        uint32_t magic = r32(b + MMIO_MAGIC);
+        if (magic != MMIO_MAGIC_HEADER) continue;
+        uint32_t did = r32(b + MMIO_DEVICE_ID);
+        if (did == VIRTIO_ID_NET) return b;
+    }
+    return NULL;
+}
+
+int virtio_net_init(void) {
+    g_net_mmio = probe_net_base();
+    if (!g_net_mmio) {
+        kprintf("virtio-net: device not found\r\n");
+        return -1;
+    }
+
+    /* reset */
+    w32(g_net_mmio + MMIO_STATUS, 0);
+    /* acknowledge and set driver status */
+    w32(g_net_mmio + MMIO_STATUS, r32(g_net_mmio + MMIO_STATUS) | VIRTIO_STATUS_ACK);
+    w32(g_net_mmio + MMIO_STATUS, r32(g_net_mmio + MMIO_STATUS) | VIRTIO_STATUS_DRIVER);
+
+    /* for now we don't negotiate advanced features */
+    w32(g_net_mmio + MMIO_STATUS, r32(g_net_mmio + MMIO_STATUS) | VIRTIO_STATUS_FEATURES_OK);
+    if (!(r32(g_net_mmio + MMIO_STATUS) & VIRTIO_STATUS_FEATURES_OK)) {
+        w32(g_net_mmio + MMIO_STATUS, r32(g_net_mmio + MMIO_STATUS) | VIRTIO_STATUS_FAILED);
+        kprintf("virtio-net: FEATURES_OK not accepted\r\n");
+        return -1;
+    }
+
+    /*TODO: queues would normally be configured here */
+
+    w32(g_net_mmio + MMIO_STATUS, r32(g_net_mmio + MMIO_STATUS) | VIRTIO_STATUS_DRIVER_OK);
+    kprintf("virtio-net: initialized (stub)\r\n");
+    return 0;
+}
+
+int virtio_net_send(const void *data, uint16_t len) {
+    (void)data;
+    (void)len;
+    /* TODO: implement transmit using virtqueue */
+    return -1;
+}
+
+int virtio_net_recv(void *buf, uint16_t buflen) {
+    (void)buf;
+    (void)buflen;
+    /* TODO: implement receive using virtqueue */
+    return -1;
+}

--- a/src/hardware/virtio/virtio_net.h
+++ b/src/hardware/virtio/virtio_net.h
@@ -1,0 +1,13 @@
+#ifndef __VIRTIO_NET_H__
+#define __VIRTIO_NET_H__
+#include "ktypes.h"
+#include "virtio.h"
+
+/* Virtio device ID for network */
+enum { VIRTIO_ID_NET = 1 };
+
+int virtio_net_init(void);
+int virtio_net_send(const void *data, uint16_t len);
+int virtio_net_recv(void *buf, uint16_t buflen);
+
+#endif /* __VIRTIO_NET_H__ */

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -11,6 +11,7 @@
 #include "virtio_input.h"
 #include "virtio_keyboard.h"
 #include "virtio_tablet.h"
+#include "virtio_net.h"
 #include "fs.h"
 #include "debug.h"
 #include "user.h"
@@ -43,12 +44,13 @@ void start_kernel(void)
     }
 	gpu_test();
 	input_init_all();
-	// if (input_init() != 0) {
-	// 	kprintf("[BOOT] input init failed!\r\n");
-    //     while (1);
-	// }
 
-	// input_test();
+	if(virtio_net_init() != 0) {
+		LOG_ERROR("[BOOT] virtio net init failed!\r\n");
+	} else {
+		lwip_port_init();
+	}
+
 	// task init should after uart and mem.
 	int hartid = read_tp();
 	task_init(hartid);

--- a/src/kernel/net/lwip_port.c
+++ b/src/kernel/net/lwip_port.c
@@ -1,0 +1,7 @@
+#include "lwip_port.h"
+#include "kprintf.h"
+
+void lwip_port_init(void) {
+    /* Placeholder for lwIP stack initialization */
+    kprintf("lwIP port stub initialized\r\n");
+}

--- a/src/kernel/net/lwip_port.h
+++ b/src/kernel/net/lwip_port.h
@@ -1,0 +1,6 @@
+#ifndef __LWIP_PORT_H__
+#define __LWIP_PORT_H__
+
+void lwip_port_init(void);
+
+#endif /* __LWIP_PORT_H__ */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 初步接入 VirtIO 网络：开机自动探测并初始化，成功后启动轻量级网络栈（lwIP 端口）。
  - 初始化失败或未检测到设备时仅记录日志，不影响系统继续运行。
  - 提供基础发送/接收接口占位，后续将完善实际数据收发能力。
  - 控制台可见初始化提示与错误信息，便于排查网络可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->